### PR TITLE
feat(core): implement alternative archive mode based on zip cli

### DIFF
--- a/packages/scooby-core/src/archive/node-archiver.ts
+++ b/packages/scooby-core/src/archive/node-archiver.ts
@@ -1,0 +1,53 @@
+import archiver from "archiver";
+import { existsSync, statSync, createWriteStream } from "fs";
+import { createTemporaryFile } from "../utils/temp";
+
+export async function archiveDirectoryUsingNodeArchiver(
+  dirPath: string
+): Promise<string> {
+  if (!existsSync(dirPath)) {
+    throw new Error(
+      "unable to archive directory, the given path does not exist"
+    );
+  }
+
+  if (!statSync(dirPath).isDirectory()) {
+    throw new Error(
+      "unable to archive directory, the given path is not a directory"
+    );
+  }
+
+  const archivePath = await createTemporaryFile("archive", ".zip");
+
+  const archiveFileStream = createWriteStream(archivePath);
+  const archive = archiver("zip", {
+    zlib: { level: 9 }, // Sets the compression level.
+  });
+  archive.on("warning", function (err) {
+    if (err.code === "ENOENT") {
+      console.warn("ARCHIVER:", err.code);
+    } else {
+      throw err;
+    }
+  });
+  archive.on("error", function (err) {
+    throw err;
+  });
+
+  archive.pipe(archiveFileStream);
+  archive.directory(dirPath, false);
+
+  await archive.finalize();
+  await waitForStreamToFinish(archiveFileStream);
+
+  return archivePath;
+}
+
+function waitForStreamToFinish(
+  stream: ReturnType<typeof createWriteStream>
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    stream.on("finish", resolve);
+    stream.on("error", reject);
+  });
+}

--- a/packages/scooby-core/src/archive/zip-cli.ts
+++ b/packages/scooby-core/src/archive/zip-cli.ts
@@ -1,0 +1,23 @@
+import { promisify } from "util";
+import { exec } from "child_process";
+import { createTemporaryFile } from "../utils/temp";
+const execPromise = promisify(exec);
+
+export async function hasZipCliInstalled(): Promise<boolean> {
+  try {
+    await execPromise("zip --version");
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function archiveDirectoryUsingZipCli(
+  dirPath: string
+): Promise<string> {
+  const archivePath = await createTemporaryFile("archive", ".zip");
+
+  await execPromise(`zip -rj '${archivePath}' '${dirPath}'`);
+
+  return archivePath;
+}


### PR DESCRIPTION
This PR introduces an alternative archiver mode based on the `zip` cli command. This mode will be used when the `zip` CLI command is being detected

## Motivation

This change has been introduced to (hopefully) mitigate the problem of Scooby getting stuck on some CircleCI builds, such as: https://app.circleci.com/pipelines/github/AnimaApp/anima-design-to-code/13935/workflows/e64e0be4-325b-4d4b-a249-15e06584969a/jobs/53178
![image](https://user-images.githubusercontent.com/100688209/222213730-b7c73271-d71f-4e84-9886-e035a2c9bafa.png)

The original library being used (node-archiver), seems to suffer from intermittent hangs in certain scenarios: https://github.com/archiverjs/node-archiver/issues/60

Also relevant: https://animaapp.slack.com/archives/C014L90LX0S/p1677662085770869
