### PR TITLE
fix: setup public NPM registry

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -264,11 +264,9 @@ jobs:
       # Publish on public NPM registry
       - run:
           name: "Publishing to public NPM registry"
-          environment:
-            NPM_AUTH_TOKEN: $NPM_PUBLISH_TOKEN
           command: |
             # Patching the NPMRC entry so that we push all packages to the public NPM registry instead of the Github NPM registry
-            echo "//registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}" > ~/.npmrc
+            echo "//registry.npmjs.org/:_authToken=${NPM_PUBLISH_TOKEN}" > ~/.npmrc
 
             ./scripts/publish_to_public_npm_registry.sh
 


### PR DESCRIPTION
This PR should fix a small error that caused an authorization error on NPM registry, causing a failure in the publish process