### PR TITLE
fix(api): fix S3 headObject error type

### DIFF
--- a/packages/scooby-api/src/s3/api.ts
+++ b/packages/scooby-api/src/s3/api.ts
@@ -1,4 +1,9 @@
-import { GetObjectCommandOutput, NoSuchKey, S3 } from "@aws-sdk/client-s3";
+import {
+  GetObjectCommandOutput,
+  NoSuchKey,
+  S3,
+  NotFound,
+} from "@aws-sdk/client-s3";
 import { v4 as uuidv4 } from "uuid";
 import { writeFile } from "fs/promises";
 import path from "path";
@@ -408,7 +413,7 @@ export class S3ScoobyAPI implements ScoobyAPI {
 
       return true;
     } catch (error) {
-      if (error instanceof NoSuchKey) {
+      if (error instanceof NotFound) {
         return false;
       }
 


### PR DESCRIPTION
This PR continues the work of #116, fixing the error code handling logic for the `headObject` operation, which seems to return `NotFound` rather than `NoSuchKey`