### PR TITLE
fix(web): fix missing metadata on some entries

### DIFF
--- a/packages/scooby-web/src/routes/report/fidelity-regression/details/MetadataTab.tsx
+++ b/packages/scooby-web/src/routes/report/fidelity-regression/details/MetadataTab.tsx
@@ -49,9 +49,17 @@ export const MetadataTab = ({ selectedId, report }: Props) => {
     ]) {
       if (entry.actual.id === selectedId) {
         return [
+          ...(entry.actual.metadata?.map((metadataEntry) => ({
+            ...metadataEntry,
+            name: `(actual) ${metadataEntry.name}`,
+          })) ?? []),
           ...(entry.expected.metadata?.map((metadataEntry) => ({
             ...metadataEntry,
-            name: `(before) ${metadataEntry.name}`,
+            name: `(truth) ${metadataEntry.name}`,
+          })) ?? []),
+          ...(entry.reference.metadata?.map((metadataEntry) => ({
+            ...metadataEntry,
+            name: `(reference) ${metadataEntry.name}`,
           })) ?? []),
         ];
       }


### PR DESCRIPTION
This PR fixes the metadata being missing on some entries while using the "fidelity-regression" report type